### PR TITLE
perf: add power state tracking

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -1,7 +1,6 @@
-use crate::common::PowerState::{Plugged, Unplugged};
 use std::ffi::OsStr;
 
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum PowerState {
     Plugged,
     Unplugged,
@@ -10,8 +9,8 @@ pub enum PowerState {
 impl From<&OsStr> for PowerState {
     fn from(value: &OsStr) -> Self {
         match value.to_str() {
-            Some("0") => Unplugged,
-            _ => Plugged,
+            Some("0") => PowerState::Unplugged,
+            _ => PowerState::Plugged,
         }
     }
 }
@@ -20,7 +19,7 @@ impl From<Option<&OsStr>> for PowerState {
     fn from(value: Option<&OsStr>) -> Self {
         match value {
             Some(value) => PowerState::from(value),
-            _ => Plugged,
+            _ => PowerState::Plugged,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod common;
 pub mod config;
 pub mod handlers;
 pub mod power_state_change_manager;
+pub mod power_state_tracker;
 pub mod systemd;
 pub mod traits;
 pub mod udev_power_monitor;

--- a/src/power_state_tracker.rs
+++ b/src/power_state_tracker.rs
@@ -1,0 +1,25 @@
+use crate::common::PowerState;
+
+#[derive(Debug, PartialEq, Clone, Default)]
+pub struct PowerStateTracker {
+    last_state: Option<PowerState>,
+}
+
+impl PowerStateTracker {
+    pub fn new() -> Self {
+        Self { last_state: None }
+    }
+
+    pub fn should_handle(&mut self, new_state: &PowerState) -> bool {
+        let should_handle = match &self.last_state {
+            None => true,                    // First event, which is always handled
+            Some(last) => last != new_state, // Handle only if state changed
+        };
+
+        if should_handle {
+            self.last_state = Some(new_state.clone());
+        }
+
+        should_handle
+    }
+}

--- a/src/udev_power_monitor.rs
+++ b/src/udev_power_monitor.rs
@@ -1,8 +1,10 @@
 use crate::common::PowerState;
 use crate::power_state_change_manager::PowerStateChangeManager;
+use crate::power_state_tracker::PowerStateTracker;
 use anyhow::{Context, Result};
 use log::info;
 use mio::{Events, Interest, Poll, Token};
+use std::sync::Mutex;
 use std::time::Duration;
 use udev::MonitorBuilder;
 
@@ -10,12 +12,14 @@ const UDEV: Token = Token(0);
 
 pub struct UdevPowerMonitor {
     power_state_change_manager: PowerStateChangeManager,
+    power_state_tracker: Mutex<PowerStateTracker>,
 }
 
 impl UdevPowerMonitor {
     pub fn new(power_state_change_manager: PowerStateChangeManager) -> Self {
         UdevPowerMonitor {
             power_state_change_manager,
+            power_state_tracker: Mutex::new(PowerStateTracker::new()),
         }
     }
 
@@ -50,12 +54,21 @@ impl UdevPowerMonitor {
 
     fn handle_event(&self, event: &udev::Event) {
         let power_state = PowerState::from(event.attribute_value("online"));
-        match power_state {
-            PowerState::Plugged => info!("Power plugged in!"),
-            PowerState::Unplugged => info!("Power unplugged!"),
-        }
-        if let Err(e) = self.power_state_change_manager.handle(power_state) {
-            eprintln!("Error handling power state change: {:?}", e);
+
+        if self
+            .power_state_tracker
+            .lock()
+            .unwrap()
+            .should_handle(&power_state)
+        {
+            match power_state {
+                PowerState::Plugged => info!("Power plugged in!"),
+                PowerState::Unplugged => info!("Power unplugged!"),
+            }
+
+            if let Err(e) = self.power_state_change_manager.handle(power_state) {
+                eprintln!("Error handling power state change: {:?}", e);
+            }
         }
     }
 }


### PR DESCRIPTION
Sometimes there might be such cases when system gives information multiple times, or for multiple devices (like double battery for laptop). In such cases, we definitely don't want to process the same power state event multiple times. So instead we will just track the power state changes, and if the state is the same as the last one, we will just ignore it.