### PR TITLE
feat: add event filtering for battery-related events

### DIFF
--- a/src/udev_power_monitor.rs
+++ b/src/udev_power_monitor.rs
@@ -60,10 +60,12 @@ impl UdevPowerMonitor {
     fn filter_event(&self, event: &udev::Event) -> bool {
         let sysname = event.sysname().to_str().unwrap_or_else(|| "");
 
-        sysname.starts_with("BAT") || sysname.starts_with("AC") || self.filter_properties(event)
+        sysname.starts_with("BAT")
+            || sysname.starts_with("AC")
+            || self.filter_event_properties(event)
     }
 
-    fn filter_properties(&self, event: &udev::Event) -> bool {
+    fn filter_event_properties(&self, event: &udev::Event) -> bool {
         event
             .properties()
             .into_iter()

--- a/src/udev_power_monitor.rs
+++ b/src/udev_power_monitor.rs
@@ -58,7 +58,7 @@ impl UdevPowerMonitor {
 
     /// Filters out events that are not related to battery directly
     fn filter_event(&self, event: &udev::Event) -> bool {
-        let sysname = event.sysname().to_str().unwrap_or_else(|| "");
+        let sysname = event.sysname().to_str().unwrap_or("");
 
         sysname.starts_with("BAT")
             || sysname.starts_with("AC")
@@ -68,7 +68,6 @@ impl UdevPowerMonitor {
     fn filter_event_properties(&self, event: &udev::Event) -> bool {
         event
             .properties()
-            .into_iter()
             .any(|p| self.filter_event_property(&p))
     }
 

--- a/src/udev_power_monitor.rs
+++ b/src/udev_power_monitor.rs
@@ -47,11 +47,32 @@ impl UdevPowerMonitor {
             for event in events.iter() {
                 if let UDEV = event.token() {
                     if let Some(udev_event) = socket.iter().next() {
-                        self.handle_event(&udev_event);
+                        if self.filter_event(&udev_event) {
+                            self.handle_event(&udev_event);
+                        }
                     }
                 }
             }
         }
+    }
+
+    /// Filters out events that are not related to battery directly
+    fn filter_event(&self, event: &udev::Event) -> bool {
+        let sysname = event.sysname().to_str().unwrap_or_else(|| "");
+
+        sysname.starts_with("BAT") || sysname.starts_with("AC") || self.filter_properties(event)
+    }
+
+    fn filter_properties(&self, event: &udev::Event) -> bool {
+        event
+            .properties()
+            .into_iter()
+            .any(|p| self.filter_event_property(&p))
+    }
+
+    fn filter_event_property(&self, property: &udev::Entry) -> bool {
+        (property.name() == "POWER_SUPPLY_TYPE" && property.value() == "Battery")
+            || (property.name() == "POWER_SUPPLY_NAME" && property.value() == "AC")
     }
 
     fn handle_event(&self, event: &udev::Event) {


### PR DESCRIPTION
Implement event filtering in UdevPowerMonitor to handle only events 
related to battery and AC power supply. Introduce `filter_event`, 
`filter_properties`, and `filter_event_property` methods to ensure 
that only relevant events are processed, improving the efficiency 
and accuracy of power monitoring